### PR TITLE
Disable dictionary management on Windows

### DIFF
--- a/src/dictionary.test.ts
+++ b/src/dictionary.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { type DictionaryEntry, DictionaryManager } from "./dictionary.js";
 
-describe("DictionaryManager", () => {
+describe.skipIf(process.platform === "win32")("DictionaryManager", () => {
 	let manager: DictionaryManager;
 
 	beforeEach(async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,8 @@ export type ErrorCode =
 	| "TEMP_FILE_ERROR"
 	// Queue errors
 	| "QUEUE_CLEARED"
+	// Platform errors
+	| "UNSUPPORTED_PLATFORM"
 	// Unknown errors
 	| "UNKNOWN_ERROR";
 
@@ -37,6 +39,8 @@ export const ErrorCode = {
 	TEMP_FILE_ERROR: "TEMP_FILE_ERROR" as const,
 	// Queue errors
 	QUEUE_CLEARED: "QUEUE_CLEARED" as const,
+	// Platform errors
+	UNSUPPORTED_PLATFORM: "UNSUPPORTED_PLATFORM" as const,
 	// Unknown errors
 	UNKNOWN_ERROR: "UNKNOWN_ERROR" as const,
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,6 +455,13 @@ server.setRequestHandler(
 				}
 
 				case "dictionary_list": {
+					if (process.platform === "win32") {
+						throw new VoicepeakError(
+							"Windows does not support dictionary management via MCP. Please use the VOICEPEAK application to manage pronunciation dictionary.",
+							ErrorCode.UNSUPPORTED_PLATFORM,
+						);
+					}
+
 					const entries = await dictionaryManager.readDictionary();
 					if (entries.length === 0) {
 						return {
@@ -485,6 +492,13 @@ server.setRequestHandler(
 				}
 
 				case "dictionary_add": {
+					if (process.platform === "win32") {
+						throw new VoicepeakError(
+							"Windows does not support dictionary management via MCP. Please use the VOICEPEAK application to manage pronunciation dictionary.",
+							ErrorCode.UNSUPPORTED_PLATFORM,
+						);
+					}
+
 					const { surface, pronunciation, priority } = args as {
 						surface: string;
 						pronunciation: string;
@@ -510,6 +524,13 @@ server.setRequestHandler(
 				}
 
 				case "dictionary_remove": {
+					if (process.platform === "win32") {
+						throw new VoicepeakError(
+							"Windows does not support dictionary management via MCP. Please use the VOICEPEAK application to manage pronunciation dictionary.",
+							ErrorCode.UNSUPPORTED_PLATFORM,
+						);
+					}
+
 					const { surface } = args as { surface: string };
 					const removed = await dictionaryManager.removeEntry(surface);
 
@@ -535,6 +556,13 @@ server.setRequestHandler(
 				}
 
 				case "dictionary_find": {
+					if (process.platform === "win32") {
+						throw new VoicepeakError(
+							"Windows does not support dictionary management via MCP. Please use the VOICEPEAK application to manage pronunciation dictionary.",
+							ErrorCode.UNSUPPORTED_PLATFORM,
+						);
+					}
+
 					const { surface } = args as { surface: string };
 					const entries = await dictionaryManager.findEntry(surface);
 
@@ -567,6 +595,13 @@ server.setRequestHandler(
 				}
 
 				case "dictionary_clear": {
+					if (process.platform === "win32") {
+						throw new VoicepeakError(
+							"Windows does not support dictionary management via MCP. Please use the VOICEPEAK application to manage pronunciation dictionary.",
+							ErrorCode.UNSUPPORTED_PLATFORM,
+						);
+					}
+
 					await dictionaryManager.clearDictionary();
 					return {
 						content: [


### PR DESCRIPTION
## Summary
- Disabled dictionary management features on Windows
- Added error message directing users to VOICEPEAK application
- Dictionary tests are skipped on Windows platform

## Background
Binary dictionary format (.dic) on Windows is incompatible with the current implementation. Users should manage pronunciation dictionary through the VOICEPEAK application GUI instead.

## Changes
- Added `UNSUPPORTED_PLATFORM` error code to errors.ts
- All dictionary tools (list/add/remove/find/clear) throw error on Windows
- Error message guides users to use VOICEPEAK application
- Dictionary tests are skipped on Windows using `describe.skipIf`

## Testing
- All tests pass on macOS/Linux (88 tests)
- Dictionary tests properly skipped on Windows